### PR TITLE
feat: format d'URL de partage compact (?p=) avec rétro-compatibilité

### DIFF
--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -175,21 +175,64 @@ export default {
     methods: {
         checkMode() {
             const params =  new URLSearchParams(document.location.search);
-            this.editMode = !params.has('g');
 
-            if(!this.editMode) {
-                let dataURL = document.location.href.split('?g=')[1];
-                // Some platforms replace the # character by %23, so we need to replace it back
-                const data = JSON.parse(JSONCrush.uncrush(decodeURI(dataURL)).replace(/%23/g, '#'));
-                this.correctGrid = data.grid;
-                this.gridRows = data.rows;
-                this.gridColumns = data.columns;
-                this.colors = data.colors;
-                this.hints = data.hints;
+            // Nouveau format compact : ?p=  (voir loadCompactPuzzle)
+            if(params.has('p')) {
+                this.editMode = false;
+                this.loadCompactPuzzle();
+            // Ancien format historique : ?g=  (conservé pour la rétro-compatibilité)
+            } else if(params.has('g')) {
+                this.editMode = false;
+                this.loadLegacyPuzzle();
             } else {
+                this.editMode = true;
                 this.colors.push(this.getRandomColor());
                 this.colors.push(this.getRandomColor());
             }
+        },
+        // Décode le nouveau format compact : grille aplatie en chaîne (1 caractère
+        // base36 par cellule), largeur et couleurs sans le « # ». Les indices
+        // (hints) sont recalculés à partir de la grille au lieu d'être transportés.
+        loadCompactPuzzle() {
+            const encodedData = document.location.href.split('?p=')[1];
+            const data = JSON.parse(JSONCrush.uncrush(decodeURIComponent(encodedData)));
+
+            const width = data.w;
+            const cells = data.g.split('').map(character => parseInt(character, 36));
+            const grid = [];
+            for(let i = 0; i < cells.length; i += width) {
+                grid.push(cells.slice(i, i + width));
+            }
+
+            // Les couleurs doivent être définies avant le calcul des indices
+            this.colors = data.c.map(color => '#' + color);
+            this.correctGrid = grid;
+            this.gridRows = grid.length;
+            this.gridColumns = width;
+            this.hints = this.computeHints(grid);
+        },
+        // Décode l'ancien format : le JSON complet (grille, couleurs, dimensions
+        // et indices) était embarqué tel quel dans l'URL.
+        loadLegacyPuzzle() {
+            let dataURL = document.location.href.split('?g=')[1];
+            // Certaines plateformes remplacent le caractère # par %23, on le restaure
+            const data = JSON.parse(JSONCrush.uncrush(decodeURI(dataURL)).replace(/%23/g, '#'));
+            this.correctGrid = data.grid;
+            this.gridRows = data.rows;
+            this.gridColumns = data.columns;
+            this.colors = data.colors;
+            this.hints = data.hints;
+        },
+        // Recalcule les indices (lignes et colonnes) à partir d'une grille de solution
+        computeHints(grid) {
+            const rows = grid.map(row => this.getHints(row));
+            const columns = [];
+            const columnCount = grid.length > 0 ? grid[0].length : 0;
+            for(let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+                const columnCells = grid.map(row => row[columnIndex]);
+                columns.push(this.getHints(columnCells));
+            }
+            return { rows, columns };
         },
         // Generate the grid array with the correct number of rows and columns
         generateGrid() {
@@ -402,19 +445,23 @@ export default {
             }
         },
         getShareLink() {
-    
+
+            // Format compact : on ne transporte que le strict nécessaire.
+            // - g : grille aplatie en une chaîne (1 caractère base36 par cellule)
+            // - w : largeur (la hauteur se déduit de la longueur de g)
+            // - c : couleurs sans le « # » (ré-ajouté au chargement)
+            // Les indices (hints) et le nombre de lignes ne sont PAS embarqués :
+            // ils sont recalculés/déduits côté lecture, ce qui raccourcit l'URL.
             const data = {
-                grid: this.grid,
-                colors: this.colors,
-                rows: this.gridRows,
-                columns: this.gridColumns,
-                hints: this.hints
+                g: this.grid.map(row => row.map(value => Number(value).toString(36)).join('')).join(''),
+                w: this.gridColumns,
+                c: this.colors.map(color => color.replace('#', ''))
             };
 
-            // JSONCrush higly compresses a JSON string
-            const encodedData = encodeURI(JSONCrush.crush(JSON.stringify(data)));
-            return `${window.location.origin}?g=${encodedData}`;
-        
+            // JSONCrush compresse fortement la chaîne JSON
+            const encodedData = encodeURIComponent(JSONCrush.crush(JSON.stringify(data)));
+            return `${window.location.origin}?p=${encodedData}`;
+
         },
         updateShareLink() {
             this.shareLink = this.getShareLink();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Contexte

Les liens de partage généraient des URLs très longues car le payload embarquait des données entièrement redondantes : les indices (`hints`, recalculables depuis la grille), le nombre de lignes/colonnes (déductibles) et une grille 2D verbeuse avec couleurs `#rrggbb`.

## Changement

Introduction d'un **nouveau format compact** (paramètre `?p=`) tout en **conservant l'ancien format** (`?g=`) pour la rétro-compatibilité.

### Différenciation des deux formats
- `?p=` → nouveau format compact (`loadCompactPuzzle`)
- `?g=` → ancien format historique, code inchangé (`loadLegacyPuzzle`)
- aucun des deux → mode édition

`checkMode` branche simplement sur la présence du paramètre : pas d'ambiguïté, aucun risque de régression sur les anciens liens.

### Format compact `?p=`
Payload réduit à l'essentiel :
- `g` : grille aplatie en une seule chaîne, 1 caractère **base36** par cellule (supporte jusqu'à 36 couleurs)
- `w` : largeur (la hauteur est déduite de la longueur de `g`)
- `c` : couleurs sans le `#` (ré-ajouté au chargement)

Les indices (`hints`) sont **recalculés** au chargement via `computeHints` (réutilise `getHints` existant). Le `#` étant retiré des couleurs, le bug d'encodage lié à `encodeURI`/`#` est évité ; le nouveau format utilise `encodeURIComponent`.

## Gain de taille mesuré (longueur de la partie encodée)

| Grille | Avant (`?g=`) | Après (`?p=`) |
|---|---|---|
| 5×5, 2 couleurs | 206 | 53 (−74 %) |
| 10×10, 3 couleurs | 283 | 70 (−75 %) |
| 15×15, 4 couleurs | 377 | 94 (−75 %) |

## Tests
- Round-trip encode → decode validé (grille, couleurs, dimensions et indices identiques) pour 5×5, 10×10, 15×15 et 20×20 (12 couleurs).
- `vue-cli-service lint` : aucune erreur.
- Anciens liens `?g=` : chemin de décodage inchangé.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25bb7d68-6ee7-4bbe-b176-4566a6fa01a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25bb7d68-6ee7-4bbe-b176-4566a6fa01a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

